### PR TITLE
fixed duplicated eTimer event

### DIFF
--- a/vnpy_rpcservice/rpc_service/engine.py
+++ b/vnpy_rpcservice/rpc_service/engine.py
@@ -110,6 +110,8 @@ class RpcEngine(BaseEngine):
     def process_event(self, event: Event) -> None:
         """调用事件"""
         if self.server.is_active():
+            if event.type == "eTimer":
+                return
             self.server.publish("", event)
 
     def write_log(self, msg: str) -> None:


### PR DESCRIPTION
当使用rpc gateway的时候，发现on_timer函数的触发频率有问题，经过仔细debug，发现除了event engine的timer在生成event外，rpc extension的timer也在不停地push eTimer event。
一般当作gateway使用时，都会有自己的engine和timer，应该不需要由gateway push出来，所以把这个event在rpc的extension给过滤掉